### PR TITLE
refactor: folder structure and unit testing

### DIFF
--- a/src/components/Join/Join.js
+++ b/src/components/Join/Join.js
@@ -17,7 +17,7 @@ const CustomCard = ({ children }) => (
   </Card>
 );
 
-const Heading = ({ text }) => (text ? <h1>{text}</h1> : null);
+export const Heading = ({ text }) => (text ? <h1>{text}</h1> : null);
 
 const Pool = ({ text = "Unassigned" }) => (
   <p style={{ color: "grey" }}>Pool ID: {text}</p>
@@ -32,9 +32,10 @@ const Join = ({ id, max, name }) => {
   const handleModalOpen = toggleModalState(true);
   const handleModalClose = toggleModalState(false);
 
-  const Name = React.createElement(Heading, {
-    text: name,
-  });
+  const Name = () =>
+    React.createElement(Heading, {
+      text: name,
+    });
 
   return (
     <>

--- a/src/components/Join/Join.js
+++ b/src/components/Join/Join.js
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Modal, Card, Button } from "antd";
+
+const CustomCard = ({ children }) => (
+  <Card
+    style={{
+      margin: "2em",
+      padding: "2em",
+    }}
+    hoverable={{
+      margin: "2em",
+      padding: "2em",
+      boxShadow: "5px 5px 8px #eeeeee",
+    }}
+  >
+    {children}
+  </Card>
+);
+
+const Heading = ({ text }) => (text ? <h1>{text}</h1> : null);
+
+const Pool = ({ text = "Unassigned" }) => (
+  <p style={{ color: "grey" }}>Pool ID: {text}</p>
+);
+
+const Join = ({ id, max, name }) => {
+  const [modal, setModal] = useState(false);
+
+  const toggleModalState = (anticipatedStateValue) => () =>
+    setModal(anticipatedStateValue);
+
+  const handleModalOpen = toggleModalState(true);
+  const handleModalClose = toggleModalState(false);
+
+  const Name = React.createElement(Heading, {
+    text: name,
+  });
+
+  return (
+    <>
+      <CustomCard>
+        <Name />
+        <Button onClick={handleModalOpen}>Join</Button>
+        {max}
+      </CustomCard>
+      <Modal
+        title={name}
+        visible={modal}
+        onOk={handleModalClose}
+        onCancel={handleModalClose}
+        okText="Join!"
+      >
+        <Name />
+        <Pool text={id} />
+      </Modal>
+    </>
+  );
+};
+
+Join.defaultProps = {};
+Join.propTypes = {};
+
+export default Join;

--- a/src/components/Join/Join.test.js
+++ b/src/components/Join/Join.test.js
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import Join, { Heading } from "./Join";
+
+const propStub = {
+  id: 1,
+  max: 10,
+  name: "Jo",
+};
+
+const checkForPool = (fn) => ({ queryByText }) =>
+  fn(expect(queryByText(`Pool ID: ${propStub.id}`)));
+
+const shouldDisplayPoolId = checkForPool((assertion) =>
+  assertion.toBeInTheDocument()
+);
+
+const shouldNotDisplayPoolId = checkForPool((assertion) =>
+  assertion.toBeNull()
+);
+
+describe('"Heading"', () => {
+  it("should render empty without a name", () => {
+    const { container } = render(<Heading />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render heading when given a name", () => {
+    const { name } = propStub;
+    render(<Heading text={name} />);
+    expect(screen.getByRole("heading")).toHaveTextContent(name);
+  });
+});
+
+describe('"Join"', () => {
+  it("should init modal hidden", () => {
+    const renderer = render(<Join {...propStub} />);
+    shouldNotDisplayPoolId(renderer);
+  });
+
+  it("should open modal", async () => {
+    const renderer = render(<Join {...propStub} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      shouldDisplayPoolId(renderer);
+    });
+  });
+});

--- a/src/components/Join/index.js
+++ b/src/components/Join/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Join";


### PR DESCRIPTION
Hey!

Alright, so not a tremendously large contribution, but I wanted to start small. I did not delete your original Join.js file, but the Join folder is meant as a replacement. Join/Join.js itself contains a few smaller components that would have been better served as independent folders, but I didn't want to introduce too many new files. The reason I like to do one folder per component is so that you can use the index file to export "public" functions and also have a test file within close proximity. 

The one thing I noticed in the code I refactored is that you need to breakdown your components further. Join still had multiple responsibilities (both functional and stylistic). It only became apparent after introducing a test for what is now <Heading />, as we needed to write coverage for when the name isn't available (an empty h1 is an accessibility problem).

Overall, I'd say the biggest thing missing in these components is ensuring the props received are as expected. Using the "prop-types" package can help, but it won't protect against bad type castings. The other thing I noticed is that there are cases where some functions do the same thing. For instance, you had multiple "handle" functions that all toggled the modal's state. Sometimes, you can write a function to produce those functions to reduce redundancy.

The test file itself is small, as there wasn't a lot of functional code to test. Mostly, you should aim for coverage on any logic branches. In this case, the only logic branches included modal visibility state and heading text. Try not to test implementation/configuration or styling, as it's somewhat a waste of time.

Is there another file you'd like to see refactoring for that I can target next?
